### PR TITLE
Add .ipynb checkpoints to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Data 
+.ipynb_checkpoints


### PR DESCRIPTION
ipynb checkpoints aren't needed on the remote repo